### PR TITLE
Add exodus-pulp hook implementers [RHELDST-7309]

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -96,3 +96,7 @@ disable=print-statement,
         # we use black code style and don't need additional checks
         bad-continuation,
         line-too-long,
+        # don't enforce use of f-strings
+        consider-using-f-string,
+        # don't enforce 'raise ... from ...'; not py2 compatible
+        raise-missing-from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+- Introduce exodus-pulp hook implementers
+- Introduce project structure, config, CI

--- a/pubtools/__init__.py
+++ b/pubtools/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/pubtools/exodus/_hooks/pulp.py
+++ b/pubtools/exodus/_hooks/pulp.py
@@ -1,0 +1,211 @@
+import json
+import logging
+import os
+import sys
+import time
+from threading import Lock
+
+import attr
+import requests
+from monotonic import monotonic
+from pubtools.pluggy import hookimpl, pm  # pylint: disable=wrong-import-order
+from requests.packages.urllib3.util.retry import (  # pylint: disable=import-error
+    Retry,
+)
+from six.moves.urllib.parse import urljoin
+
+LOG = logging.getLogger("pubtools-exodus")
+
+# pylint: disable=unused-argument
+
+
+class ExodusPulpHandler:  # pylint: disable=too-many-instance-attributes
+    def __init__(self):
+        # These variables are set only through environment variables
+        # expected on all applicable hosts.
+        self.gw_url = os.getenv("EXODUS_GW_URL")
+        self.gw_env = os.getenv("EXODUS_GW_ENV")
+        self.gw_crt = os.getenv("EXODUS_GW_CERT")
+        self.gw_key = os.getenv("EXODUS_GW_KEY")
+
+        # These defaults are not advertised or expected but can be controlled
+        # by environment variables when needed (e.g., testing).
+        self.retries = int(os.getenv("EXODUS_GW_RETRIES") or "5")
+        self.timeout = int(os.getenv("EXODUS_GW_TIMEOUT") or "900")
+        self.wait = int(os.getenv("EXODUS_GW_WAIT") or "5")
+
+        self.lock = Lock()
+        self.session = None
+        self.publish = None
+
+    def exodus_enabled(self):
+        enable_vals = ["true", "t", "1", "yes", "y"]
+        return os.getenv("EXODUS_ENABLED", "False").lower() in enable_vals
+
+    def new_session(self):
+        retry_strategy = Retry(
+            total=int(self.retries),
+            backoff_factor=1,
+            status_forcelist=[429, 500, 502, 503, 504],
+        )
+        adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
+
+        out = requests.Session()
+        out.cert = (self.gw_crt, self.gw_key)
+        out.mount(self.gw_url, adapter)
+
+        return out
+
+    def unpack_response(self, response):
+        """Raise if response was not successful.
+
+        This is the same as response.raise_for_status(), merely wrapping it
+        to ensure the body is logged when possible.
+        """
+
+        try:
+            response.raise_for_status()
+        except Exception as outer:
+            try:
+                body = response.json()
+            except:
+                raise outer
+
+            LOG.error("unsuccessful response from exodus-gw: %s", body)
+            raise
+
+    def do_request(self, **kwargs):
+        if not self.session:
+            self.session = self.new_session()
+
+        resp = self.session.request(**kwargs)
+        self.unpack_response(resp)
+        return resp
+
+    def check_cert(self):
+        """Issue request to exodus-gw to identify permissions."""
+
+        for key, val in {"cert": self.gw_crt, "key": self.gw_key}.items():
+            if not val:
+                LOG.debug(
+                    "exodus-gw %s not found, authentication may fail", key
+                )
+
+        auth_url = urljoin(self.gw_url, "/whoami")
+        resp = self.do_request(method="GET", url=auth_url)
+        context = resp.json()
+
+        for user_type, ident in (
+            ("client", "serviceAccountId"),
+            ("user", "internalUsername"),
+        ):
+            typed_ctx = context[user_type]
+            if typed_ctx["authenticated"]:
+                roles = [str(role) for role in typed_ctx["roles"]]
+                LOG.debug(
+                    "authenticated with exodus-gw at %s as %s %s (roles: %s)",
+                    self.gw_url,
+                    user_type,
+                    typed_ctx[ident],
+                    roles,
+                )
+                break
+        else:
+            LOG.debug("not authenticated with exodus-gw at %s", self.gw_url)
+
+    def new_publish(self):
+        """Issue request to exodus-gw to create a new publish."""
+        self.check_cert()
+
+        publish_url = os.path.join(self.gw_url, self.gw_env, "publish")
+        resp = self.do_request(method="POST", url=publish_url)
+        return resp.json()
+
+    def poll_commit_completion(self, commit):
+        """Issues request(s) to exodus-gw for the commit's state, returning
+        if/when the state is either "COMPLETE" or "FAILED".
+        """
+
+        timelimit = monotonic() + self.timeout
+
+        msg = "exodus-gw commit %s to %s" % (commit["id"], self.gw_url)
+
+        while monotonic() < timelimit:
+            task_url = urljoin(self.gw_url, commit["links"]["self"])
+            resp = self.do_request(method="GET", url=task_url)
+            task = resp.json()
+
+            if task["state"] == "COMPLETE":
+                LOG.info("%s complete", msg)
+                return task
+            if task["state"] == "FAILED":
+                raise RuntimeError("%s failed" % msg)
+
+            time.sleep(self.wait)
+
+        raise RuntimeError("Polling for %s timed out" % msg)
+
+    @hookimpl
+    def pulp_repository_pre_publish(self, repository, options):
+        """Invoked as the first step in publishing a Pulp repository.
+
+        This implementation adds to each config the --exodus-publish argument,
+        attaching the repository to an exodus-gw publish.
+
+        Args:
+            repository (:class:`~pubtools.pulplib.Repository`):
+                The repository to be published.
+            options (:class:`~pubtools.pulplib.PublishOptions`):
+                The options to use in publishing.
+        Returns:
+            options (:class:`~pubtools.pulplib.PublishOptions`):
+                The adjusted options used for this publish.
+        """
+
+        if not self.exodus_enabled():
+            return None
+
+        with self.lock:
+            if not self.publish:
+                self.publish = self.new_publish()
+                LOG.debug("created exodus-gw publish %s", self.publish["id"])
+
+        args = (
+            list(options.rsync_extra_args) if options.rsync_extra_args else []
+        )
+        args.append("--exodus-publish=%s" % self.publish["id"])
+        return attr.evolve(options, rsync_extra_args=args)
+
+    @hookimpl
+    def task_pulp_flush(self):
+        """Invoked during task execution after successful completion of all
+        Pulp publishes.
+
+        This implementation commits the active exodus-gw publish, making
+        the content visible on the target CDN environment.
+        """
+
+        if not self.publish:
+            LOG.debug("no exodus-gw publish to commit")
+            return
+
+        commit_url = urljoin(self.gw_url, self.publish["links"]["commit"])
+        resp = self.do_request(method="POST", url=commit_url)
+        commit = resp.json()
+
+        task = self.poll_commit_completion(commit)
+        LOG.info(
+            "committed exodus-gw publish: %s", json.dumps(task, sort_keys=True)
+        )
+
+    @hookimpl
+    def task_stop(self):
+        pm.unregister(self)
+
+
+@hookimpl
+def task_start():
+    pm.register(ExodusPulpHandler())
+
+
+pm.register(sys.modules[__name__])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+six
+backoff
+requests
+monotonic
+pubtools>=0.3.0

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,11 @@ setup(
     ],
     install_requires=get_requirements(),
     python_requires=">=2.6",
+    entry_points={
+        "pubtools.hooks": [
+            "pubtools-exodus-pulp = pubtools.exodus._hooks.pulp",
+        ]
+    },
     project_urls={
         "Changelog": "https://github.com/release-engineering/pubtools-exodus/blob/main/CHANGELOG.md",
     },

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,8 @@
 mock
 pytest
 pytest-cov
+requests-mock
+frozenlist2
 
 mypy; python_version > "3.0"
 black; python_version > "3.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import attr
+from frozenlist2 import frozenlist
+
+
+def frozenlist_or_none_converter(obj, map_fn=(lambda x: x)):
+    if obj is not None:
+        return frozenlist(map_fn(obj))
+    return None
+
+
+@attr.s(kw_only=True, frozen=True)
+class FakePublishOptions(object):
+    """Options controlling a repository"""
+
+    rsync_extra_args = attr.ib(
+        default=None, type=list, converter=frozenlist_or_none_converter  # type: ignore
+    )

--- a/tests/test_exodus_pulp_hooks.py
+++ b/tests/test_exodus_pulp_hooks.py
@@ -1,0 +1,348 @@
+import json
+import logging
+import os
+
+import mock
+import pytest
+from pubtools.pluggy import pm, task_context
+from requests.exceptions import HTTPError
+from six.moves.urllib.parse import urljoin
+
+from .conftest import FakePublishOptions
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "EXODUS_ENABLED": "True",
+        "EXODUS_GW_URL": "https://exodus-gw.example.com",
+        "EXODUS_GW_ENV": "test",
+        "EXODUS_GW_CERT": "path/to/ex.crt",
+        "EXODUS_GW_KEY": "path/to/ex.key",
+    },
+)
+def test_exodus_pulp_typical(requests_mock, caplog):
+    url = os.getenv("EXODUS_GW_URL")
+    env = os.getenv("EXODUS_GW_ENV")
+
+    caplog.set_level(logging.DEBUG, "pubtools-exodus")
+
+    auth_resp = {
+        "client": {
+            "roles": [],
+            "authenticated": False,
+            "serviceAccountId": "testapp",
+        },
+        "user": {
+            "roles": ["publisher"],
+            "authenticated": True,
+            "internalUsername": "tester",
+        },
+    }
+    auth_url = urljoin(url, "/whoami")
+    requests_mock.get(auth_url, json=auth_resp, status_code=200)
+
+    publish_resp = {
+        "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "env": "test",
+        "links": {
+            "self": "/test/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08",
+            "commit": "/test/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08/commit",
+        },
+        "items": [],
+    }
+    publish_url = os.path.join(url, env, "publish")
+    requests_mock.post(publish_url, json=publish_resp, status_code=200)
+
+    commit_resp = {
+        "id": "9187ec3d-ba51-4a3b-9298-e534b0869350",
+        "publish_id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "state": "COMPLETE",
+        "updated": "2022-01-18 18:16:52.000000+00:00",
+        "links": {"self": "/task/9187ec3d-ba51-4a3b-9298-e534b0869350"},
+    }
+    commit_url = os.path.join(url, publish_resp["links"]["commit"])
+    requests_mock.post(commit_url, json=commit_resp, status_code=200)
+
+    task_url = os.path.join(url, commit_resp["links"]["self"])
+    requests_mock.get(task_url, json=commit_resp, status_code=200)
+
+    # Simulate task start
+    with task_context():
+        # Simulate repo publish; call prep-publish hook
+        hook_rets = pm.hook.pulp_repository_pre_publish(
+            repository=None,
+            options=FakePublishOptions(rsync_extra_args=["--existing-arg"]),
+        )
+        hook_rets = [ret for ret in hook_rets if ret is not None]
+
+        assert (
+            "authenticated with exodus-gw at %s as user tester (roles: ['publisher'])"
+            % url
+            in caplog.text
+        )
+        assert (
+            "created exodus-gw publish 497f6eca-6276-4993-bfeb-53cbbbba6f08"
+            in caplog.text
+        )
+        # The pre-publish hook should've returned options with exodus-publish
+        # arg appended to existing rsync_extra_args.
+        assert hook_rets[0] == FakePublishOptions(
+            rsync_extra_args=[
+                "--existing-arg",
+                "--exodus-publish=497f6eca-6276-4993-bfeb-53cbbbba6f08",
+            ],
+        )
+
+        # Simulate completion of pulp publish; call task pulp flush
+        pm.hook.task_pulp_flush()
+
+        assert (
+            "committed exodus-gw publish: %s"
+            % json.dumps(commit_resp, sort_keys=True)
+            in caplog.text
+        )
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "EXODUS_ENABLED": "True",
+        "EXODUS_GW_URL": "https://exodus-gw.example.com",
+        "EXODUS_GW_ENV": "test",
+    },
+)
+def test_exodus_pulp_no_auth(requests_mock, caplog):
+    url = os.getenv("EXODUS_GW_URL")
+    env = os.getenv("EXODUS_GW_ENV")
+
+    caplog.set_level(logging.DEBUG, "pubtools-exodus")
+
+    auth_resp = {
+        "client": {
+            "roles": [],
+            "authenticated": False,
+            "serviceAccountId": "testapp",
+        },
+        "user": {
+            "roles": [],
+            "authenticated": False,
+            "internalUsername": "tester",
+        },
+    }
+    auth_url = urljoin(os.getenv("EXODUS_GW_URL"), "/whoami")
+    requests_mock.get(auth_url, json=auth_resp, status_code=200)
+
+    publish_url = os.path.join(url, env, "publish")
+    requests_mock.post(
+        publish_url, json={"detail": "Not Found"}, status_code=404
+    )
+
+    with task_context():
+        with pytest.raises(HTTPError) as exc_info:
+            pm.hook.pulp_repository_pre_publish(
+                repository=None, options=FakePublishOptions()
+            )
+
+        assert "exodus-gw cert not found" in caplog.text
+        assert "exodus-gw key not found" in caplog.text
+        assert "not authenticated with exodus-gw at %s" % url in caplog.text
+        assert (
+            str(exc_info.value)
+            == "404 Client Error: None for url: https://exodus-gw.example.com/test/publish"
+        )
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "EXODUS_ENABLED": "True",
+        "EXODUS_GW_URL": "https://exodus-gw.example.com",
+        "EXODUS_GW_ENV": "test",
+        "EXODUS_GW_CERT": "path/to/ex.crt",
+        "EXODUS_GW_KEY": "path/to/ex.key",
+    },
+)
+def test_exodus_pulp_commit_fail(requests_mock, caplog):
+    url = os.getenv("EXODUS_GW_URL")
+    env = os.getenv("EXODUS_GW_ENV")
+
+    caplog.set_level(logging.DEBUG, "pubtools-exodus")
+
+    auth_resp = {
+        "client": {
+            "roles": [],
+            "authenticated": False,
+            "serviceAccountId": "testapp",
+        },
+        "user": {
+            "roles": ["publisher"],
+            "authenticated": True,
+            "internalUsername": "tester",
+        },
+    }
+    auth_url = urljoin(url, "/whoami")
+    requests_mock.get(auth_url, json=auth_resp, status_code=200)
+
+    publish_resp = {
+        "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "env": "test",
+        "links": {
+            "self": "/test/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08",
+            "commit": "/test/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08/commit",
+        },
+        "items": [],
+    }
+    publish_url = os.path.join(url, env, "publish")
+    requests_mock.post(publish_url, json=publish_resp, status_code=200)
+
+    commit_resp = {
+        "id": "9187ec3d-ba51-4a3b-9298-e534b0869350",
+        "publish_id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "state": "IN_PROGRESS",
+        "updated": "2022-01-18 18:16:52.000000+00:00",
+        "links": {"self": "/task/9187ec3d-ba51-4a3b-9298-e534b0869350"},
+    }
+    commit_url = os.path.join(url, publish_resp["links"]["commit"])
+    requests_mock.post(commit_url, json=commit_resp, status_code=200)
+
+    task_resp = {
+        "id": "9187ec3d-ba51-4a3b-9298-e534b0869350",
+        "publish_id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "state": "FAILED",
+        "updated": "2022-01-18 18:16:53.000000+00:00",
+        "links": {"self": "/task/9187ec3d-ba51-4a3b-9298-e534b0869350"},
+    }
+    task_url = os.path.join(url, commit_resp["links"]["self"])
+    requests_mock.get(task_url, json=task_resp, status_code=200)
+
+    with task_context():
+        pm.hook.pulp_repository_pre_publish(
+            repository=None,
+            options=FakePublishOptions(),
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            pm.hook.task_pulp_flush()
+
+        assert str(exc_info.value) == "exodus-gw commit %s to %s failed" % (
+            task_resp["id"],
+            url,
+        )
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "EXODUS_ENABLED": "True",
+        "EXODUS_GW_URL": "https://exodus-gw.example.com",
+        "EXODUS_GW_ENV": "test",
+        "EXODUS_GW_CERT": "path/to/ex.crt",
+        "EXODUS_GW_KEY": "path/to/ex.key",
+        "EXODUS_GW_TIMEOUT": "1",
+        "EXODUS_GW_WAIT": "1",
+    },
+)
+def test_exodus_pulp_commit_timeout(requests_mock, caplog):
+    url = os.getenv("EXODUS_GW_URL")
+    env = os.getenv("EXODUS_GW_ENV")
+
+    caplog.set_level(logging.DEBUG, "pubtools-exodus")
+
+    auth_resp = {
+        "client": {
+            "roles": [],
+            "authenticated": False,
+            "serviceAccountId": "testapp",
+        },
+        "user": {
+            "roles": ["publisher"],
+            "authenticated": True,
+            "internalUsername": "tester",
+        },
+    }
+    auth_url = urljoin(url, "/whoami")
+    requests_mock.get(auth_url, json=auth_resp, status_code=200)
+
+    publish_resp = {
+        "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "env": "test",
+        "links": {
+            "self": "/test/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08",
+            "commit": "/test/publish/497f6eca-6276-4993-bfeb-53cbbbba6f08/commit",
+        },
+        "items": [],
+    }
+    publish_url = os.path.join(url, env, "publish")
+    requests_mock.post(publish_url, json=publish_resp, status_code=200)
+
+    commit_resp = {
+        "id": "9187ec3d-ba51-4a3b-9298-e534b0869350",
+        "publish_id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+        "state": "IN_PROGRESS",
+        "updated": "2022-01-18 18:16:52.000000+00:00",
+        "links": {"self": "/task/9187ec3d-ba51-4a3b-9298-e534b0869350"},
+    }
+    commit_url = os.path.join(url, publish_resp["links"]["commit"])
+    requests_mock.post(commit_url, json=commit_resp, status_code=200)
+
+    task_url = os.path.join(url, commit_resp["links"]["self"])
+    requests_mock.get(task_url, json=commit_resp, status_code=200)
+
+    with task_context():
+        pm.hook.pulp_repository_pre_publish(
+            repository=None,
+            options=FakePublishOptions(),
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            pm.hook.task_pulp_flush()
+
+        assert str(
+            exc_info.value
+        ) == "Polling for exodus-gw commit %s to %s timed out" % (
+            commit_resp["id"],
+            url,
+        )
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "EXODUS_ENABLED": "True",
+        "EXODUS_GW_URL": "https://exodus-gw.example.com",
+    },
+)
+def test_exodus_pulp_bad_response(requests_mock):
+    auth_url = urljoin(os.getenv("EXODUS_GW_URL"), "/whoami")
+    requests_mock.get(auth_url, json=None, status_code=503)
+
+    with task_context():
+        with pytest.raises(HTTPError) as exc_info:
+            pm.hook.pulp_repository_pre_publish(repository=None, options={})
+
+        assert (
+            str(exc_info.value)
+            == "503 Server Error: None for url: https://exodus-gw.example.com/whoami"
+        )
+
+
+@mock.patch.dict(os.environ, {"EXODUS_ENABLED": "True"})
+def test_exodus_pulp_no_publish(caplog):
+    caplog.set_level(logging.DEBUG, "pubtools-exodus")
+
+    with task_context():
+        pm.hook.task_pulp_flush()
+
+        assert "no exodus-gw publish to commit" in caplog.text
+
+
+@mock.patch.dict(os.environ, {"EXODUS_ENABLED": "False"})
+def test_exodus_pulp_disabled(caplog):
+    caplog.set_level(logging.DEBUG, "pubtools-exodus")
+
+    with task_context():
+        # With Exodus disabled, this should be a no-op.
+        pm.hook.pulp_repository_pre_publish(repository=None, options={})
+
+    assert caplog.text == ""


### PR DESCRIPTION
This commit introduces the ExodusPulpHandler, which has hook
implementers for pulp_repository_pre_publish and task_pulp_flush.

The pulp_repository_pre_publish implementer, activated before
publishing a repo, creates a publish in exodus-gw if one doesn't
already exist and appends the --exodus-publish argument to the
repo's PublishOptions.rsync_extra_args.

The task_pulp_flush implementer, activated once Pulp publishes
have finished, commits the exodus-gw publish.