### PR TITLE
pubtools-exodus-push supports multiple src,dest pairs [RHELDST-10121]

### DIFF
--- a/pubtools/exodus/task.py
+++ b/pubtools/exodus/task.py
@@ -12,11 +12,12 @@ LOG_FORMAT = "%(asctime)s [%(levelname)-8s] %(message)s"
 class ExodusTask(ExodusGatewaySession):
     """Base class for Exodus tasks"""
 
-    def __init__(self):
+    def __init__(self, args=None):
         super(ExodusTask, self).__init__()
 
         self._args = None
         self._extra_args = None
+        self._override_args = args
 
         self.parser = ArgumentParser(
             formatter_class=RawDescriptionHelpFormatter
@@ -31,7 +32,7 @@ class ExodusTask(ExodusGatewaySession):
         else parse with defined options and return the args
         """
         if not self._args:
-            self._args, _ = self.parser.parse_known_args()
+            self._args, _ = self.parser.parse_known_args(self._override_args)
         return self._args
 
     @property
@@ -41,7 +42,9 @@ class ExodusTask(ExodusGatewaySession):
         else parse and return the remaining args
         """
         if not self._extra_args:
-            _, self._extra_args = self.parser.parse_known_args()
+            _, self._extra_args = self.parser.parse_known_args(
+                self._override_args
+            )
         return self._extra_args
 
     def _basic_args(self):

--- a/tests/test_exodus_push_task.py
+++ b/tests/test_exodus_push_task.py
@@ -10,16 +10,7 @@ from pubtools.exodus._tasks.push import entry_point
 
 @pytest.mark.parametrize(
     "sys_argv",
-    [
-        [
-            "",
-            "--debug",
-            "--source",
-            "/path/to/my-source",
-            "--dest",
-            "/path/to/my-dest",
-        ]
-    ],
+    [["", "--debug", "/path/to/my-source,/path/to/my-dest"]],
 )
 @mock.patch("pubtools.exodus._tasks.push.ExodusPushTask.run")
 def test_exodus_push_entry_point(
@@ -31,54 +22,60 @@ def test_exodus_push_entry_point(
     assert mock_run.call_count == 1
 
 
-@pytest.mark.parametrize(
-    "sys_argv",
-    [
-        [
-            "",
-            "--debug",
-            "-vvv",
-            "--exodus-conf",
-            "/path/to/my-conf",
-            "--dry-run",
-            "--source",
-            "/path/to/my-source",
-            "--dest",
-            "/path/to/my-dest",
-        ]
-    ],
-)
 @mock.patch("pubtools.exodus._tasks.push.subprocess.Popen")
-def test_exodus_push_typical(
-    mock_popen, successful_gw_task, patch_sys_argv, caplog
-):
+def test_exodus_push_typical(mock_popen, successful_gw_task, caplog):
     mock_popen.return_value.stdout = io.StringIO(
         u("fake exodus-rsync output\nfake task info\n")
     )
     mock_popen.return_value.wait.return_value = 0
 
-    caplog.set_level(logging.DEBUG, "pubtools-exodus")
-    cmd = [
-        "exodus-rsync",
-        "/path/to/my-source",
-        "exodus:/path/to/my-dest",
+    args = [
+        "--debug",
         "-vvv",
+        "--dry-run",
+        "/path/to/my-source,/path/to/my-dest",
+        "/path/to/other-source,/path/to/other-dest",
         "--exodus-conf",
         "/path/to/my-conf",
-        "--dry-run",
+    ]
+    caplog.set_level(logging.DEBUG, "pubtools-exodus")
+    cmds = [
+        [
+            "exodus-rsync",
+            "--exodus-publish",
+            "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+            "/path/to/my-source",
+            "exodus:/path/to/my-dest",
+            "-vvv",
+            "--dry-run",
+            "--exodus-conf",
+            "/path/to/my-conf",
+        ],
+        [
+            "exodus-rsync",
+            "--exodus-publish",
+            "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+            "/path/to/other-source",
+            "exodus:/path/to/other-dest",
+            "-vvv",
+            "--dry-run",
+            "--exodus-conf",
+            "/path/to/my-conf",
+        ],
     ]
 
-    entry_point()
+    entry_point(args)
 
     assert "Exodus push begins" in caplog.text
     assert "fake exodus-rsync output" in caplog.text
     assert "fake task info" in caplog.text
     assert "Exodus push is complete" in caplog.text
 
-    assert mock_popen.call_count == 1
-    mock_popen.assert_called_with(
-        cmd, stderr=-2, stdout=-1, universal_newlines=True
-    )
+    assert mock_popen.call_count == 2
+    for cmd in cmds:
+        mock_popen.assert_any_call(
+            cmd, stderr=-2, stdout=-1, universal_newlines=True
+        )
 
 
 @pytest.mark.parametrize(
@@ -88,10 +85,7 @@ def test_exodus_push_typical(
             "",
             "--debug",
             "--verbose",
-            "--source",
-            "/path/to/my-source",
-            "--dest",
-            "/path/to/my-dest",
+            "/path/to/my-source,/path/to/my-dest",
         ]
     ],
 )
@@ -107,6 +101,8 @@ def test_exodus_push_subprocess_error(
     caplog.set_level(logging.DEBUG, "pubtools-exodus")
     cmd = [
         "exodus-rsync",
+        "--exodus-publish",
+        "497f6eca-6276-4993-bfeb-53cbbbba6f08",
         "/path/to/my-source",
         "exodus:/path/to/my-dest",
         "-v",


### PR DESCRIPTION
In order to successfully push kickstart tree repos and origin-only
content, the pubtools-exodus-push entry point must be invoked with
several source and destination pairs.

The pubtools-exodus-push entry point will be used to push kickstart
tree repos and origin-only (Goldengate) content. The kickstart tree
staging structures contain several kickstart tree repos. Each
kickstart tree repository represents a unique source-destination
pair, and thus requires a dedicated exodus-rsync run. Each piece of
origin-only content also requires a dedicated exodus-rsync invocation,
as each piece of content will have a unique, sha256-specific
destination path.

example usage:

    pubtools-exodus-push --push-item '/src/path,/dest/path'
    --push-item '/other/src/,/other/dest' [...]