### PR TITLE
Don't attempt to populate vars if Exodus is disabled [RHELDST-10992]

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -99,4 +99,6 @@ disable=print-statement,
         # don't enforce use of f-strings
         consider-using-f-string,
         # don't enforce 'raise ... from ...'; not py2 compatible
-        raise-missing-from
+        raise-missing-from,
+        # don't enforce Python3 style super(); not py2 compatible
+        super-with-arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+- Check EXODUS_ENABLED before populating vars from env 
 
 ## [1.0.0] - 2022-03-23
 

--- a/pubtools/exodus/_hooks/pulp.py
+++ b/pubtools/exodus/_hooks/pulp.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import sys
 from threading import Lock
 
@@ -20,10 +19,6 @@ class ExodusPulpHandler(ExodusGatewaySession):
         super(ExodusPulpHandler, self).__init__()
 
         self.lock = Lock()
-
-    def exodus_enabled(self):
-        enable_vals = ["true", "t", "1", "yes", "y"]
-        return os.getenv("EXODUS_ENABLED", "False").lower() in enable_vals
 
     @hookimpl
     def pulp_repository_pre_publish(self, repository, options):
@@ -64,6 +59,9 @@ class ExodusPulpHandler(ExodusGatewaySession):
         This implementation commits the active exodus-gw publish, making
         the content visible on the target CDN environment.
         """
+
+        if not self.exodus_enabled():
+            return
 
         if not self.publish:
             LOG.debug("no exodus-gw publish to commit")

--- a/pubtools/exodus/gateway.py
+++ b/pubtools/exodus/gateway.py
@@ -144,9 +144,16 @@ class ExodusGatewaySession(
         commit = resp.json()
         return commit
 
+    def exodus_enabled(self):
+        enable_vals = ["true", "t", "1", "yes", "y"]
+        return os.getenv("EXODUS_ENABLED", "False").lower() in enable_vals
+
     def _populate_exodus_gw_vars(self):
         """Populate exodus gateway details from environment variables. All exodus CDN transactions
         go through exodus gateway."""
+        if not self.exodus_enabled():
+            return
+
         self.gw_env = os.getenv("EXODUS_GW_ENV")
         if not self.gw_env:
             raise RuntimeError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ class FakePublishOptions(object):
 def patch_env_vars(monkeypatch, env_map=None):
     if not env_map:
         env_map = {
+            "EXODUS_ENABLED": "true",
             "EXODUS_GW_URL": "https://exodus-gw.test.redhat.com",
             "EXODUS_GW_ENV": "test",
             "EXODUS_GW_CERT": "/path/test.crt",

--- a/tests/test_exodus_gateway_connection.py
+++ b/tests/test_exodus_gateway_connection.py
@@ -13,12 +13,14 @@ from pubtools.exodus.gateway import ExodusGatewaySession
     "env_vars",
     [
         (
+            {"key": "EXODUS_ENABLED", "val": "true"},
             {"key": "EXODUS_GW_CERT", "val": "/fake/cert"},
             {"key": "EXODUS_GW_KEY", "val": "/fake/key"},
             {"key": "EXODUS_GW_ENV", "val": "test"},
             {"key": "EXODUS_GW_URL", "val": ""},
         ),
         (
+            {"key": "EXODUS_ENABLED", "val": "true"},
             {
                 "key": "EXODUS_GW_URL",
                 "val": "https://exodus-gw.test.redhat.com",
@@ -28,6 +30,7 @@ from pubtools.exodus.gateway import ExodusGatewaySession
             {"key": "EXODUS_GW_CERT", "val": ""},
         ),
         (
+            {"key": "EXODUS_ENABLED", "val": "true"},
             {
                 "key": "EXODUS_GW_URL",
                 "val": "https://exodus-gw.test.redhat.com",
@@ -37,6 +40,7 @@ from pubtools.exodus.gateway import ExodusGatewaySession
             {"key": "EXODUS_GW_KEY", "val": ""},
         ),
         (
+            {"key": "EXODUS_ENABLED", "val": "true"},
             {
                 "key": "EXODUS_GW_URL",
                 "val": "https://exodus-gw.test.redhat.com",


### PR DESCRIPTION
Previously, env vars were being gathered even when EXODUS_ENBALED was
absent or falsey because var population was happening on the base class
while EXODUS_ENABLED was checked on child class.

This commit moves the check up to the base class, ExodusGatewaySession,
and invokes it within __populate_exodus_gw_vars. An additional
invokation was added in the hook implementor task_pulp_flush to prevent
any log messages from being displayed when Exodus isn't enabled.