### PR TITLE
Handle missing config more gracefully [RHELDST-11078]

### DIFF
--- a/pubtools/exodus/_hooks/pulp.py
+++ b/pubtools/exodus/_hooks/pulp.py
@@ -37,7 +37,7 @@ class ExodusPulpHandler(ExodusGatewaySession):
                 The adjusted options used for this publish.
         """
 
-        if not self.exodus_enabled():
+        if not self.exodus_enabled:
             return None
 
         with self.lock:
@@ -60,7 +60,7 @@ class ExodusPulpHandler(ExodusGatewaySession):
         the content visible on the target CDN environment.
         """
 
-        if not self.exodus_enabled():
+        if not self.exodus_enabled:
             return
 
         if not self.publish:

--- a/pubtools/exodus/task.py
+++ b/pubtools/exodus/task.py
@@ -13,7 +13,7 @@ class ExodusTask(ExodusGatewaySession):
     """Base class for Exodus tasks"""
 
     def __init__(self, args=None):
-        super(ExodusTask, self).__init__()
+        super(ExodusTask, self).__init__(exodus_enabled=True)
 
         self._args = None
         self._extra_args = None

--- a/tests/test_exodus_gateway_connection.py
+++ b/tests/test_exodus_gateway_connection.py
@@ -57,11 +57,10 @@ def test_missing_env_vars(monkeypatch, env_vars):
         if not env_var["val"]:
             missing_key = env_var["key"]
     with pytest.raises(RuntimeError) as exc_info:
-        ExodusGatewaySession()
+        ExodusGatewaySession().new_publish()
         assert (
             str(exc_info.value)
-            == "Environment variable '%s' is not set, skipping exodus publish"
-            % missing_key
+            == "Environment variable '%s' is not set" % missing_key
         )
 
 

--- a/tests/test_exodus_push_task.py
+++ b/tests/test_exodus_push_task.py
@@ -32,8 +32,14 @@ def test_exodus_push_doc_parser(mock_push_task):
     assert mock_push_task.call_count == 1
 
 
+@pytest.mark.parametrize("exodus_enabled", [True, None])
 @mock.patch("pubtools.exodus._tasks.push.subprocess.Popen")
-def test_exodus_push_typical(mock_popen, successful_gw_task, caplog):
+def test_exodus_push_typical(
+    mock_popen, exodus_enabled, successful_gw_task, caplog, monkeypatch
+):
+    if exodus_enabled == None:
+        monkeypatch.setenv("EXODUS_ENABLED", "")
+
     mock_popen.return_value.stdout = io.StringIO(
         u("fake exodus-rsync output\nfake task info\n")
     )


### PR DESCRIPTION
Prior to this commit, the pubtools-exodus-push entry point would
crash during invocation attempts when EXODUS_ENABLED was not set.
Now, exodus is enabled for pubtools-exodus tasks by default.