### PR TITLE
Reduce repeated parsing attempts on tasks [RHELDST-12184]

### DIFF
--- a/pubtools/exodus/task.py
+++ b/pubtools/exodus/task.py
@@ -31,8 +31,16 @@ class ExodusTask(ExodusGatewaySession):
         Return the args if available from previous parse
         else parse with defined options and return the args
         """
-        if not self._args:
-            self._args, _ = self.parser.parse_known_args(self._override_args)
+        if self._args is None:
+            # Parse a copy of the raw args, as the parse may modify them.
+            to_parse = (
+                list(self._override_args) if self._override_args else None
+            )
+            # If args are unset, it's likely extra_args are too.
+            # Set both here to avoid repeating the operation later.
+            self._args, self._extra_args = self.parser.parse_known_args(
+                to_parse
+            )
         return self._args
 
     @property
@@ -41,10 +49,12 @@ class ExodusTask(ExodusGatewaySession):
         Return the remaining args from the previous parse,
         else parse and return the remaining args
         """
-        if not self._extra_args:
-            _, self._extra_args = self.parser.parse_known_args(
-                self._override_args
+        if self._extra_args is None:
+            # Parse a copy of the raw args, as the parse may modify them.
+            to_parse = (
+                list(self._override_args) if self._override_args else None
             )
+            _, self._extra_args = self.parser.parse_known_args(to_parse)
         return self._extra_args
 
     def _basic_args(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import attr
 import pytest
@@ -35,14 +34,6 @@ def patch_env_vars(monkeypatch, env_map=None):
     for var in env_map.keys():
         monkeypatch.setenv(var, env_map[var])
     yield env_map
-
-
-@pytest.fixture
-def patch_sys_argv(sys_argv):
-    old_argv = sys.argv
-    sys.argv[:] = sys_argv
-    yield
-    sys.argv = old_argv
 
 
 @pytest.fixture

--- a/tests/test_exodus_task.py
+++ b/tests/test_exodus_task.py
@@ -1,8 +1,25 @@
+import mock
 import pytest
 
 from pubtools.exodus.task import ExodusTask
 
 
-def test_run(patch_env_vars):
+def test_run():
     with pytest.raises(NotImplementedError) as e:
         ExodusTask().run()
+
+
+# Mock argv or pytest arguments will be captured.
+@mock.patch("sys.argv", [""])
+def test_exodus_task_args():
+    task = ExodusTask()
+
+    # Should have basic args
+    assert task.args.__dict__ == {"debug": False, "verbose": 0}
+    # Should have no extra_args
+    assert task.extra_args == []
+
+    # Reset extra_args, simulating case in which task.args isn't called
+    task._extra_args = None
+    # Calling extra_args should change value to empty list
+    assert task.extra_args == []


### PR DESCRIPTION
Previously, the parser was called to parse arguments too frequently
(when args or extra_args were called or anytime after if they held empty
structures). This commit implements a few changes to reduce the number
of parser calls and maintain the integrity of the original argument list
should multiple calls be unavoidable.