### PR TITLE
Resolve python2.7-related exodus-rsync log buffering [RHELDST-14217]

### DIFF
--- a/pubtools/exodus/_tasks/push.py
+++ b/pubtools/exodus/_tasks/push.py
@@ -83,7 +83,8 @@ class ExodusPushTask(ExodusTask):
                 stderr=subprocess.STDOUT,
                 universal_newlines=True,
             )
-            for line in proc.stdout:
+
+            for line in iter(proc.stdout.readline, ""):
                 LOG.info(line.strip())
 
             ret = proc.wait()


### PR DESCRIPTION
Prior to this commit, the pubtools-exodus-push CLI would buffer the exodus-rsync output. This buffering issue was only present when invoking pubtools-exodus-push with Python 2.7.

The exodus-rsync output is now logged in a way that is compatible with both Python 2.7 and Python 3.X. Buffering is no longer present, regardless of the Python version used to invoke pubtools-exodus-push.