### PR TITLE
Drop Python2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,26 +7,6 @@ on:
     branches: [main]
 
 jobs:
-  py27-ci:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python 2.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: '2.7'
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get install -y krb5-config libkrb5-dev
-          python -m pip install -U pip
-          pip install tox
-
-      - name: Run auto-tests (Python 2.7)
-        run: tox -e py27
-
   standard-ci:
     runs-on: ubuntu-latest
 

--- a/pubtools/exodus/gateway.py
+++ b/pubtools/exodus/gateway.py
@@ -1,13 +1,13 @@
 import logging
 import os
 import time
+from urllib.parse import urljoin
 
 import requests
 from monotonic import monotonic
 from requests.packages.urllib3.util.retry import (  # pylint: disable=import-error
     Retry,
 )
-from six.moves.urllib.parse import urljoin
 
 LOG = logging.getLogger("pubtools-exodus")
 LOG_FORMAT = "%(asctime)s [%(levelname)-8s] %(message)s"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-six
 requests
 monotonic
 pubtools>=0.3.0

--- a/setup.py
+++ b/setup.py
@@ -33,14 +33,12 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=get_requirements(),
-    python_requires=">=2.6",
+    python_requires=">=3.6",
     entry_points={
         "pubtools.hooks": [
             "pubtools-exodus-pulp = pubtools.exodus._hooks.pulp",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import os
+from urllib.parse import urljoin
 
 import attr
 import pytest
 from frozenlist2 import frozenlist
-from six.moves.urllib.parse import urljoin
 
 
 def frozenlist_or_none_converter(obj, map_fn=(lambda x: x)):

--- a/tests/test_exodus_gateway_connection.py
+++ b/tests/test_exodus_gateway_connection.py
@@ -1,10 +1,10 @@
 import logging
 import os
+from urllib.parse import urljoin
 
 import mock
 import pytest
 from requests.exceptions import HTTPError
-from six.moves.urllib.parse import urljoin
 
 from pubtools.exodus.gateway import ExodusGatewaySession
 

--- a/tests/test_exodus_push_task.py
+++ b/tests/test_exodus_push_task.py
@@ -5,7 +5,6 @@ import os
 import mock
 import pytest
 from pushsource import PushItem, Source
-from six import u
 
 from pubtools.exodus._tasks.push import ExodusPushTask, doc_parser, entry_point
 
@@ -50,7 +49,7 @@ def test_exodus_push_typical(
         monkeypatch.setenv("EXODUS_ENABLED", "")
 
     mock_popen.return_value.stdout = io.StringIO(
-        u("fake exodus-rsync output\nfake task info\n")
+        "fake exodus-rsync output\nfake task info\n"
     )
     mock_popen.return_value.wait.return_value = 0
 
@@ -127,7 +126,7 @@ def test_exodus_push_typical(
 @mock.patch("pubtools.exodus._tasks.push.subprocess.Popen")
 def test_exodus_push_subprocess_error(mock_popen, successful_gw_task, caplog):
     mock_popen.return_value.stdout = io.StringIO(
-        u("fake exodus-rsync output\nfake task info\n")
+        "fake exodus-rsync output\nfake task info\n"
     )
     mock_popen.return_value.wait.return_value = 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py38, static, docs
+envlist = py38, static, docs
 
 [testenv]
 deps=


### PR DESCRIPTION
After Supercharge Pub 3 was delivered, Python 2 support is no longer required in it's dependencies as well. Dropping Python 2 will make the repos easier to maintain and will speed up Tox and Github Actions since some steps can be removed.