### PR TITLE
Introduce var to disable just pulp hook [RHELDST-20492]

### DIFF
--- a/pubtools/exodus/_hooks/pulp.py
+++ b/pubtools/exodus/_hooks/pulp.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 from threading import Lock
 
@@ -48,6 +49,17 @@ class ExodusPulpHandler(ExodusGatewaySession):
         )
         args.append("--exodus-publish=%s" % self.publish["id"])
         return attr.evolve(options, rsync_extra_args=args)
+
+    @property
+    def exodus_enabled(self):
+        # If this hook-specific env var is set, then it solely determines
+        # whether the hook is enabled.
+        enabled = os.getenv("EXODUS_PULP_HOOK_ENABLED")
+        if enabled is not None:
+            return enabled.lower() in ["true", "t", "1", "yes", "y"]
+
+        # Otherwise, we let super decide, which will check a more generic env var.
+        return super().exodus_enabled
 
     def ensure_publish_committed(self):
         """Commit the current publish, if and only if there is a current publish

--- a/tests/test_exodus_pulp_hooks.py
+++ b/tests/test_exodus_pulp_hooks.py
@@ -64,8 +64,23 @@ def test_exodus_pulp_no_publish(patch_env_vars, caplog):
         assert "No exodus-gw publish to commit" in caplog.text
 
 
-def test_exodus_pulp_disabled(monkeypatch, caplog):
+def test_exodus_pulp_disabled_global(monkeypatch, caplog):
+    """Tests disablement of hook via global EXODUS_ENABLED var."""
     monkeypatch.setenv("EXODUS_ENABLED", "False")
+    caplog.set_level(logging.INFO, "pubtools-exodus")
+
+    with task_context():
+        # With Exodus disabled, this should be a no-op.
+        pm.hook.pulp_repository_pre_publish(repository=None, options={})
+
+    # Should not have generated anything INFO or higher.
+    assert caplog.text == ""
+
+
+def test_exodus_pulp_disabled_hook(monkeypatch, caplog):
+    """Tests disablement of hook via hook-specific var."""
+    monkeypatch.setenv("EXODUS_ENABLED", "True")
+    monkeypatch.setenv("EXODUS_PULP_HOOK_ENABLED", "0")
     caplog.set_level(logging.INFO, "pubtools-exodus")
 
     with task_context():


### PR DESCRIPTION
There are currently some issues which should be addressed by disabling the pubtools-exodus pulp publish hook.
However, doing that by setting EXODUS_ENABLED=0 would affect some other things as well.

It would be better to have a way of disabling or enabling the hook without affecting anything else. Implement that.