### PR TITLE
Fix certain requests not retrying

### DIFF
--- a/pubtools/exodus/gateway.py
+++ b/pubtools/exodus/gateway.py
@@ -42,6 +42,7 @@ class ExodusGatewaySession(
             total=int(self.retries),
             backoff_factor=1,
             status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=Retry.DEFAULT_ALLOWED_METHODS.union(["POST"]),
         )
         adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
 


### PR DESCRIPTION
Per [1], the Retry class defaults to allowing retries only on certain methods, not including POST.

That makes sense since POST requests are not generally expected to be idempotent. However, we've intentionally designed the relevant exodus-gw APIs (create/commit publish) to be retry-safe anyway. Enable retries of POST so that temporary failures on those endpoints can also be recovered from.

[1] https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry