### PR TITLE
Onboard test coverage to Codecov [RHELDST-40404]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   standard-ci:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +31,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: tox -e cov-ci
-    
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: coverage.xml
+          fail_ci_if_error: false
+
       - name: Run static analysis
         run: tox -e static
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,6 @@ frozenlist2
 mypy; python_version > "3.0"
 black; python_version > "3.0"
 pylint; python_version > "3.0"
-coveralls; python_version > "3.0"
 sphinx; python_version > "3.0"
 sphinx-argparse; python_version > "3.0"
 alabaster; python_version > "3.0"

--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,7 @@ commands=
 passenv=GITHUB_*
 usedevelop=true
 commands=
-	pytest --cov=pubtools.exodus {posargs}
-	coveralls --service=github
+	pytest --cov=pubtools.exodus --cov-report=xml {posargs}
 
 [testenv:docs]
 use_develop=true


### PR DESCRIPTION
Updates cov-ci testenv to generate coverage.xml report. Adds the codecov action to the standard-ci workflow in ci.yml. Removes coveralls.